### PR TITLE
Avoid triggering a cpp file compilation.

### DIFF
--- a/Sources/Cbgfx/dummy.c
+++ b/Sources/Cbgfx/dummy.c
@@ -1,6 +1,5 @@
 #include "bgfx/bgfx.h"
 
-extern
 void dummy() {
 	bgfx_init(BGFX_RENDERER_TYPE_COUNT, 0, 0, NULL, NULL);
 }


### PR DESCRIPTION
Swift Package Manager is gonna try to link libc++ when a cpp file is present. This is causing troubles for platforms where the c++ stl is not strictly defined. Changing this to a c file avoids this problem.